### PR TITLE
Fix document generation build errors and add cleanup API

### DIFF
--- a/TMS.WebApi/Controllers/CleanupController.cs
+++ b/TMS.WebApi/Controllers/CleanupController.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.IO;
+using System.Linq;
+
+namespace TMS.WebApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CleanupController : ControllerBase
+    {
+        private readonly ILogger<CleanupController> _logger;
+        private const string TmsGeneratedPath = @"C:\\ManteqStorage_Shared\\TmsGenerated";
+
+        public CleanupController(ILogger<CleanupController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpPost("cleanup-tmsgenerated")]
+        public IActionResult CleanupTmsGeneratedFolder()
+        {
+            if (!Directory.Exists(TmsGeneratedPath))
+            {
+                return NotFound($"Directory not found: {TmsGeneratedPath}");
+            }
+
+            var files = Directory.GetFiles(TmsGeneratedPath);
+            int deleted = 0;
+            foreach (var file in files)
+            {
+                try
+                {
+                    System.IO.File.Delete(file);
+                    deleted++;
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogWarning(ex, $"Failed to delete file: {file}");
+                }
+            }
+
+            return Ok(new { message = $"Deleted {deleted} files from {TmsGeneratedPath}", deletedFiles = deleted });
+        }
+    }
+}

--- a/test-payloads-tms.json
+++ b/test-payloads-tms.json
@@ -3,7 +3,7 @@
     "description": "Generate document from email template",
     "endpoint": "POST http://localhost:5267/api/templates/generate",
     "payload": {
-      "templateId": "96cec0ae-a1f9-4e01-8e07-16ddd57b4b25",
+      "templateId": "E6913CB9-F0C3-42CA-89E4-05F9955E505B",
       "propertyValues": {
         "ICS_CustomerName": "Ahmed Al-Mansouri",
         "ICS_PolicyNumber": "POL-2025-001234",


### PR DESCRIPTION
- Fixed return types in DocumentGenerationService for UpdateSimpleFields and UpdateComplexFields (now return int, not Dictionary)
- Added missing using for StringBuilder
- Added CleanupController with POST /api/cleanup/cleanup-tmsgenerated to delete all files in C:\ManteqStorage_Shared\TmsGenerated