### PR TITLE
Configure CORS for Angular frontend integration

### DIFF
--- a/CMS.Webapi/Program.cs
+++ b/CMS.Webapi/Program.cs
@@ -81,14 +81,19 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
-// Add CORS for development
+// Add CORS for Angular frontend
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.AllowAnyOrigin()
+        policy.WithOrigins(
+                "http://localhost:4200",
+                "http://localhost:4201",
+                "https://localhost:4200",
+                "https://localhost:4201")
               .AllowAnyMethod()
-              .AllowAnyHeader();
+              .AllowAnyHeader()
+              .AllowCredentials();
     });
 });
 

--- a/EmailService.WebApi/Program.cs
+++ b/EmailService.WebApi/Program.cs
@@ -127,14 +127,19 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 
-// Configure CORS if needed
+// Configure CORS for Angular frontend
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.AllowAnyOrigin()
+        policy.WithOrigins(
+                "http://localhost:4200",
+                "http://localhost:4201",
+                "https://localhost:4200",
+                "https://localhost:4201")
               .AllowAnyMethod()
-              .AllowAnyHeader();
+              .AllowAnyHeader()
+              .AllowCredentials();
     });
 });
 

--- a/TMS.WebApi/Program.cs
+++ b/TMS.WebApi/Program.cs
@@ -121,14 +121,19 @@ builder.Services.AddSwaggerGen(c =>
     }
 });
 
-// Configure CORS if needed
+// Configure CORS for Angular frontend
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowAll", policy =>
     {
-        policy.AllowAnyOrigin()
+        policy.WithOrigins(
+                "http://localhost:4200",
+                "http://localhost:4201",
+                "https://localhost:4200",
+                "https://localhost:4201")
               .AllowAnyMethod()
-              .AllowAnyHeader();
+              .AllowAnyHeader()
+              .AllowCredentials();
     });
 });
 


### PR DESCRIPTION
- Allow Angular origins (localhost:4200, 4201) for all APIs
- Enable credentials support for authenticated requests
- Configure both HTTP and HTTPS origins
- Applied to CMS, TMS, and Email Service APIs